### PR TITLE
Handle HTTP 429 messages from Strava

### DIFF
--- a/messagehandler.go
+++ b/messagehandler.go
@@ -118,6 +118,10 @@ func (msg *StravaWebhookMessage) WriteToDatabase() error {
 		}
 		defer response.Body.Close()
 
+		if response.StatusCode == 429 {
+			return fmt.Errorf("Strava responded with HTTP 429: Too many requests when retrieving activity data (activity %v for user %v)", msg.ObjectID, msg.OwnerID)
+		}
+
 		if err := json.NewDecoder(response.Body).Decode(&activity); err != nil {
 			return fmt.Errorf("Could not decode response body: %v", err)
 		}

--- a/userhandler.go
+++ b/userhandler.go
@@ -77,6 +77,12 @@ func FetchNewUserActivities(user *dbmodel.User) error {
 	if err != nil {
 		return fmt.Errorf("Could not get user activities: %v", err)
 	}
+
+	// Except HTTP 429: too many requests
+	if req.Response.StatusCode == 429 {
+		return fmt.Errorf("Strava request limit has been reached")
+	}
+
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", user.AccessToken))
 
 	res, err := client.Do(req)


### PR DESCRIPTION
Adds logging for HTTP 429 responses. Received when Strava's request limits have been reached.